### PR TITLE
Added shortcuts which don't give the top option and filter out shortcuts which are superstrings of other shortcuts

### DIFF
--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -388,18 +388,18 @@ const optimizedShortcuts = (targets) => {
       }
     }
   }
-  while(altShortcuts.length > 0 && shortcuts.length < NUM_SHORTCUTS){
-    let temp = [];
-    for(const altSubString of altShortcuts){
-      if (altSubString.length == currentLength){
-        shortcuts.push(altSubString);
-      }
-      else{
-        temp.push(altSubString);
-      }
-    }
-    altShortcuts = temp;
-    currentLength += 1;
+// If not enough shortcuts were found, try to fill with the alternative shortcuts to reach at least NUM_SHORTCUTS. When including a shortcut, ensure that all the ones with the same length are included too.
+  if (altShortcuts.length > 0 && shortcuts.length < NUM_SHORTCUTS) {
+    // Take at least enough to fill up to NUM_SHORTCUTS
+    const neededCount = Math.min(
+      NUM_SHORTCUTS - shortcuts.length,
+      altShortcuts.length
+    );
+    const maxAltLength = altShortcuts[neededCount - 1].length;
+    // Take all the altShortcuts with the same length as the longest that is needed
+    shortcuts = shortcuts.concat(
+      altShortcuts.filter((s) => s.length <= maxAltLength)
+    );
   }
   return shortcuts.length ? shortcuts : [bestSubstring];
 };

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -3,7 +3,7 @@
 // @namespace    http://tampermonkey.net/
 // @version      1.7
 // @description  Displays at least ~3~ 10 of the shortest shortcuts for an anime after guessing phase, defined as the shortest substrings of length 10 or less for which the target anime (or any of its alt names) is a suggestion in the dropdown list (a 1 character penalty represented by "↓" is applied for every position below the top that the name associated with the shortcut appears). Adapted from https://github.com/tutti-amq/amq-scripts/blob/main/animeShortcuts.user.js All shortcuts (that aren't longer version of shorter shortcuts) with the smallest length are displayed. Click on a shortcut to highlight it and move it to the front of the list.
-// @author       Einlar, Tutti, (modified by kombofuud)
+// @author       Einlar, Tutti, kombofuud
 // @match        https://animemusicquiz.com/*
 // @match        https://*.animemusicquiz.com/*
 // @downloadURL  https://github.com/Einlar/AMQScripts/raw/main/amqVivaceShortcuts.user.js

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         AMQ Vivace! Optimized Shortcuts
 // @namespace    http://tampermonkey.net/
-// @version      1.6
+// @version      1.7
 // @description  Displays at least ~3~ 10 of the shortest shortcuts for an anime after guessing phase, defined as the shortest substrings of length 10 or less for which the target anime (or any of its alt names) is a suggestion in the dropdown list (a 1 character penalty represented by "↓" is applied for every position below the top that the name associated with the shortcut appears). Adapted from https://github.com/tutti-amq/amq-scripts/blob/main/animeShortcuts.user.js All shortcuts (that aren't longer version of shorter shortcuts) with the smallest length are displayed. Click on a shortcut to highlight it and move it to the front of the list.
 // @author       Einlar, Tutti, (modified by kombofuud)
 // @match        https://animemusicquiz.com/*

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -305,7 +305,11 @@ const optimizedShortcuts = (targets) => {
 
   let minPos = Infinity;
   let bestSubstring = "";
+
+  /** @type {string[]} */
   let shortcuts = [];
+
+  /** @type {string[]} */
   let altShortcuts = [];
   let currentLength = 0;
 

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -278,6 +278,25 @@ const mapToAlternativeSubstrings = (substring) => {
 };
 
 /**
+ * Check if str2 is a subsequence of str1
+ *
+ * @param {string} str1
+ * @param {string} str2
+ * @returns {boolean}
+ */
+const subsequenceQ = (str1, str2) => {
+  let i = 0;
+  let j = 0;
+  while(i < str1.length && j < str2.length){
+    if(str1[i] == str2[j]){
+      j++;
+    }
+    i++;
+  }
+  return (j == str2.length);
+}
+
+/**
  * Find the optimal shortcuts matching any of the targets.
  *
  * @param {string[]} targets
@@ -356,22 +375,14 @@ const optimizedShortcuts = (targets) => {
       if(substring.length > MAX_SUBSTRING_LENGTH || (TOP_SHORTCUTS_ONLY && pos > 0)){
           continue;
       }
-      //If the shortcut found has a substring that's already in shortcuts list don't add it. Otherwise, do add it.
+      //Check if any of the current shortcuts are a subsequence of the new shortcut. (e.g. if "uron" is a shortcut, "uroun" wouldn't be added because it has the same letters in the same order + extra letters)
       let superStringQ = false;
       if(!FULL_SHORTCUTS){
         for(const currentShortcut of shortcuts.concat(altShortcuts)){
           if(substring.length < currentShortcut.length){
               continue;
           }
-          let i = 0;
-          let j = 0;
-          while(i < substring.length && j < currentShortcut.length){
-            if(currentShortcut[j] == substring[i]){
-              j++;
-            }
-            i++;
-          }
-          if(j >= currentShortcut.length){
+          if(subsequenceQ(substring, currentShortcut)){
             superStringQ = true;
             break;
           }

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -43,17 +43,22 @@ const MAX_DROPDOWN_ITEMS = 25;
 /**
  * The maximum length of shortcuts to consider. If a "perfect" shortcut is found (i.e. one that is the first suggestion in the dropdown list), the search will stop.
  */
-const MAX_SUBSTRING_LENGTH = 10;
+const MAX_SUBSTRING_LENGTH = 3;
 
 /**
  * Minimum number of shortcuts to display.
  */
-const NUM_SHORTCUTS = 3;
+const NUM_SHORTCUTS = 10;
 
 /**
  * Whether or not to include shortcuts containing shorter shortcuts. (e.g. if "hi" is a shortcut, this will determine whether "his" is also a shortcut)
  */
 const FULL_SHORTCUTS = false;
+
+/**
+ * Whether or not to include shortcuts that contain down arrows (shortcuts which bring a show on the menu, but not the top position)
+ */
+const TOP_SHORTCUTS_ONLY = false;
 
 /**
  * @see SEARCH_CHARACTER_REPLACEMENT_MAP from AMQ code
@@ -147,7 +152,7 @@ const ALLOWED_SPECIAL_CHARACTERS = [
  *
  * @type {string[]}
  */
-const DISALLOWED_SPECIAL_CHARACTERS = ["∞", "△", "↓"];
+const DISALLOWED_SPECIAL_CHARACTERS = ["∞","△","↓"];
 
 /**
  * Shortcuts to be shown
@@ -308,12 +313,13 @@ const optimizedShortcuts = (targets) => {
     const newLength = substring.length;
 
     // Search for longer substrings only if there are not enough shortcuts yet, but display *all* the shortest ones
-    if (newLength > currentLength) {
+    if (newLength > currentLength){
       let temp = [];
-      for (const altSubString of altShortcuts) {
-        if (altSubString.length == currentLength) {
+      for(const altSubString of altShortcuts){
+        if (altSubString.length == currentLength){
           shortcuts.push(altSubString);
-        } else {
+        }
+        else{
           temp.push(altSubString);
         }
       }
@@ -332,49 +338,51 @@ const optimizedShortcuts = (targets) => {
       const pos = Math.min(...positions);
       if (pos < minPos) {
         minPos = pos;
-        bestSubstring = substring;
+        bestSubstring = substring+"↓".repeat(pos);
       }
-      substring = substring + "↓".repeat(pos);
-      if (substring.length > MAX_SUBSTRING_LENGTH) {
-        continue;
+      substring = substring+"↓".repeat(pos);
+      if(substring.length > MAX_SUBSTRING_LENGTH || (TOP_SHORTCUTS_ONLY && pos > 0)){
+          continue;
       }
       //If the shortcut found has a substring that's already in shortcuts list don't add it. Otherwise, do add it.
       let superStringQ = false;
-      if (!FULL_SHORTCUTS) {
-        for (const currentShortcut of shortcuts.concat(altShortcuts)) {
-          if (substring.length < currentShortcut.length) {
-            continue;
+      if(!FULL_SHORTCUTS){
+        for(const currentShortcut of shortcuts.concat(altShortcuts)){
+          if(substring.length < currentShortcut.length){
+              continue;
           }
           let i = 0;
           let j = 0;
-          while (i < substring.length && j < currentShortcut.length) {
-            if (currentShortcut[j] == substring[i]) {
+          while(i < substring.length && j < currentShortcut.length){
+            if(currentShortcut[j] == substring[i]){
               j++;
             }
             i++;
           }
-          if (j >= currentShortcut.length) {
+          if(j >= currentShortcut.length){
             superStringQ = true;
             break;
           }
         }
       }
       //if (shortcuts.find(shortcut => substring.includes(shortcut)) == undefined || FULL_SHORTCUTS){
-      if (!superStringQ) {
-        if (pos == 0) {
+      if (!superStringQ){
+        if (pos == 0){
           shortcuts.push(substring);
-        } else {
+        }
+        else{
           altShortcuts.push(substring);
         }
       }
     }
   }
-  while (altShortcuts.length > 0 && shortcuts.length < NUM_SHORTCUTS) {
+  while(altShortcuts.length > 0 && shortcuts.length < NUM_SHORTCUTS){
     let temp = [];
-    for (const altSubString of altShortcuts) {
-      if (altSubString.length == currentLength) {
+    for(const altSubString of altShortcuts){
+      if (altSubString.length == currentLength){
         shortcuts.push(altSubString);
-      } else {
+      }
+      else{
         temp.push(altSubString);
       }
     }

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -147,7 +147,7 @@ const ALLOWED_SPECIAL_CHARACTERS = [
  *
  * @type {string[]}
  */
-const DISALLOWED_SPECIAL_CHARACTERS = ["∞","△","↓"];
+const DISALLOWED_SPECIAL_CHARACTERS = ["∞", "△", "↓"];
 
 /**
  * Shortcuts to be shown
@@ -308,13 +308,12 @@ const optimizedShortcuts = (targets) => {
     const newLength = substring.length;
 
     // Search for longer substrings only if there are not enough shortcuts yet, but display *all* the shortest ones
-    if (newLength > currentLength){
+    if (newLength > currentLength) {
       let temp = [];
-      for(const altSubString of altShortcuts){
-        if (altSubString.length == currentLength){
+      for (const altSubString of altShortcuts) {
+        if (altSubString.length == currentLength) {
           shortcuts.push(altSubString);
-        }
-        else{
+        } else {
           temp.push(altSubString);
         }
       }
@@ -335,49 +334,47 @@ const optimizedShortcuts = (targets) => {
         minPos = pos;
         bestSubstring = substring;
       }
-      substring = substring+"↓".repeat(pos);
-      if(substring.length > MAX_SUBSTRING_LENGTH){
-          continue;
+      substring = substring + "↓".repeat(pos);
+      if (substring.length > MAX_SUBSTRING_LENGTH) {
+        continue;
       }
       //If the shortcut found has a substring that's already in shortcuts list don't add it. Otherwise, do add it.
       let superStringQ = false;
-      if(!FULL_SHORTCUTS){
-        for(const currentShortcut of shortcuts.concat(altShortcuts)){
-          if(substring.length < currentShortcut.length){
-              continue;
+      if (!FULL_SHORTCUTS) {
+        for (const currentShortcut of shortcuts.concat(altShortcuts)) {
+          if (substring.length < currentShortcut.length) {
+            continue;
           }
           let i = 0;
           let j = 0;
-          while(i < substring.length && j < currentShortcut.length){
-            if(currentShortcut[j] == substring[i]){
+          while (i < substring.length && j < currentShortcut.length) {
+            if (currentShortcut[j] == substring[i]) {
               j++;
             }
             i++;
           }
-          if(j >= currentShortcut.length){
+          if (j >= currentShortcut.length) {
             superStringQ = true;
             break;
           }
         }
       }
       //if (shortcuts.find(shortcut => substring.includes(shortcut)) == undefined || FULL_SHORTCUTS){
-      if (!superStringQ){
-        if (pos == 0){
+      if (!superStringQ) {
+        if (pos == 0) {
           shortcuts.push(substring);
-        }
-        else{
+        } else {
           altShortcuts.push(substring);
         }
       }
     }
   }
-  while(altShortcuts.length > 0 && shortcuts.length < NUM_SHORTCUTS){
+  while (altShortcuts.length > 0 && shortcuts.length < NUM_SHORTCUTS) {
     let temp = [];
-    for(const altSubString of altShortcuts){
-      if (altSubString.length == currentLength){
+    for (const altSubString of altShortcuts) {
+      if (altSubString.length == currentLength) {
         shortcuts.push(altSubString);
-      }
-      else{
+      } else {
         temp.push(altSubString);
       }
     }

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -320,12 +320,20 @@ const optimizedShortcuts = (targets) => {
           shortcuts.push(altSubString);
         }
         else{
-          temp.push(altSubString);
+    // When searching for longer substrings, first pick those from the altShortcuts list
+    if (newLength > currentLength) {
+      altShortcuts = altShortcuts.filter((s) => {
+        // Move altShortcuts of the currentLength to the shortcuts list
+        if (s.length === currentLength) {
+          shortcuts.push(s);
+          return false;
         }
-      }
-      altShortcuts = temp;
+        // Keep the others in the altShortcuts list
+        return true;
+      });
+      // Re-check the stopping condition after moving the altShortcuts to the shortcuts list
+      if (shortcuts.length >= NUM_SHORTCUTS) break;
     }
-    if (newLength > currentLength && shortcuts.length >= NUM_SHORTCUTS) break;
 
     const suggestions = getSuggestions(substring);
     currentLength = newLength;


### PR DESCRIPTION
Added the following functionality (Similar to other pull request, but with the added variable, and I've done some testing to ensure that the new variables work as intended):

Shows shortcuts that don't pick the first option (indicated with a number of down arrows showing how far below the top answer they are) Excludes all shortcuts which are super sequences of other shortcuts.

Added variable "FULL_SHORTCUTS". If true, it allows the user to view shortcuts which are supersequences of other shortcuts. (set to false by default).

Added variable "TOP_SHORTCUTS_ONLY". If true, it prevents the user from seeing shortcuts which do not put the show as the first option in the menu as long as there exists at least 1 shortcut which puts the show at the top of the menu. (false by default)

Normalization map now excludes the triangle character and the down arrow. (I don't think the latter is necessary, but if a show comes out with the down arrow, it would screw up the formatting, plus, who would want to type a down arrow?)

If no shortcuts are found, "bestSubstring" now has down arrows to indicate the position on the list. (This means that if no substrings are found, the user may see down arrows even if the opted not to. This can occur if the user disallows the ° symbol and sets TOP_SHORTCUTS_ONLY to true. Then no substrings are found and it returns "gin↓↓↓").

Game also searches for shortcuts in "AltAnimeNamesAnswers" (other shows that have the same song)