### PR TITLE
Limit Characters instead of Blacklisting wierd characters

### DIFF
--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -74,6 +74,14 @@ const TOP_SHORTCUTS_ONLY = false;
 const MAX_LENGTH_DIFFERENTIAL = 10;
 
 /**
+* Prevents any nonstandard keyboard characters from appearing
+*/
+
+const WHITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST = true;
+const KEYBOARD_LAYOUT = "ANSI_104" // pick between "ANSI_104", "ISO", "JIS" or "CUSTOM"
+const CUSTOM_LAYOUT = "";
+
+/**
  * @see SEARCH_CHARACTER_REPLACEMENT_MAP from AMQ code
  */
 const NORMALIZATION_MAP = {
@@ -164,13 +172,33 @@ const ALLOWED_SPECIAL_CHARACTERS = [
 
 /**
  * These special characters are not matched by AMQ with a space, but they should still not be allowed in shortcuts.
+ * (only applicable when WHITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST is false)
  *
  * @type {string[]}
  */
 const DISALLOWED_SPECIAL_CHARACTERS = ["∞", "△", "↓","°","♡","∬"];
-const FULL_CHARACTER_LIST = "`1234567890-=~!@#$%^&*()_+qwertyuiop[]\\asdfghjkl;'zxcvbnm,./QWERTYUIOP{}|ASDFGHJKL:\"ZXCVBNM<>? ";
-const WHITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST = true;
 
+/**
+* Determines a list of allowed characters when HITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST is true
+* I hope I got the character sets right for JIS and ISO, if I got any of the characters wrong (or the wrong version of a character), please let @kombofuud know in the scripts-for-games channel.
+*/
+const ANSI_104 = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/? ";
+const ISO = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`¬!\"£$%^&*()-_=+[{]};:'@#~\\|',<.>/? ";
+const JIS = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`¥!\"#$%^&'()-_=+[{｢]}｣\\|;:『'…』,<.>/?・° ";
+let FULL_CHARACTER_LIST;
+switch (KEYBOARD_LAYOUT){
+  case "ISO":
+    FULL_CHARACTER_LIST = ISO;
+    break;
+  case "JIS":
+    FULL_CHARACTER_LIST = ISO;
+    break;
+  case "CUSTOM":
+    FULL_CHARACTER_LIST = CUSTOM_LAYOUT;
+    break;
+  default:
+    FULL_CHARACTER_LIST = ANSI_104;
+}
 /**
  * Shortcuts to be shown
  *

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -56,7 +56,7 @@ const MAX_SUBSTRING_LENGTH = 10;
 /**
  * Minimum number of shortcuts to display.
  */
-const NUM_SHORTCUTS = 3;
+const NUM_SHORTCUTS = 10;
 
 /**
  * Whether or not to include shortcuts containing shorter shortcuts. (e.g. if "hi" is a shortcut, this will determine whether "his" is also a shortcut)
@@ -71,7 +71,7 @@ const TOP_SHORTCUTS_ONLY = false;
 /**
  * how much longer a shortcut can be than the shortest one (e.g. if there's a 3 length shortcut and the variable is set to 3, nothing longer than 6 will be suggested)
  */
-const MAX_LENGTH_DIFFERENTIAL = 3;
+const MAX_LENGTH_DIFFERENTIAL = 10;
 
 /**
  * @see SEARCH_CHARACTER_REPLACEMENT_MAP from AMQ code
@@ -126,6 +126,7 @@ const NORMALIZATION_MAP = {
   "@": " ",
   _: " ",
   "#": " ",
+  "'": " ",
   é: "e",
   ê: "e",
   ë: "e",
@@ -158,6 +159,7 @@ const ALLOWED_SPECIAL_CHARACTERS = [
   "@",
   "_",
   "#",
+  "'",
 ];
 
 /**
@@ -165,7 +167,9 @@ const ALLOWED_SPECIAL_CHARACTERS = [
  *
  * @type {string[]}
  */
-const DISALLOWED_SPECIAL_CHARACTERS = ["∞", "△", "↓"];
+const DISALLOWED_SPECIAL_CHARACTERS = ["∞", "△", "↓","°","♡","∬"];
+const FULL_CHARACTER_LIST = "`1234567890-=~!@#$%^&*()_+qwertyuiop[]\\asdfghjkl;'zxcvbnm,./QWERTYUIOP{}|ASDFGHJKL:\"ZXCVBNM<>? ";
+const WHITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST = true;
 
 /**
  * Shortcuts to be shown
@@ -240,7 +244,12 @@ const mapToAlternativeSubstrings = (substring) => {
 
   // Apply mandatory replacements
   let normalized = substring.replace(/./g, (char) => {
-    if (DISALLOWED_SPECIAL_CHARACTERS.includes(char)) return "";
+    if (WHITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST) {
+        if (!FULL_CHARACTER_LIST.includes(char)) return "";
+    }
+    else{
+        if (DISALLOWED_SPECIAL_CHARACTERS.includes(char)) return "";
+    }
     if (ALLOWED_SPECIAL_CHARACTERS.includes(/** @type {any} */ (char)))
       return char;
     return NORMALIZATION_MAP[char] || char;

--- a/amqVivaceShortcuts.user.js
+++ b/amqVivaceShortcuts.user.js
@@ -1,8 +1,8 @@
 // ==UserScript==
 // @name         AMQ Vivace! Shortcuts
 // @namespace    http://tampermonkey.net/
-// @version      1.8
-// @description  Displays at least 3 of the shortest shortcuts for an anime after guessing phase, defined as the shortest substrings of length 10 or less for which the target anime (or any of its alt names) is a suggestion in the dropdown list (a 1 character penalty represented by "↓" is applied for every position below the top that the name associated with the shortcut appears). Adapted from https://github.com/tutti-amq/amq-scripts/blob/main/animeShortcuts.user.js All shortcuts (that aren't longer version of shorter shortcuts) with the smallest length are displayed. Click on a shortcut to highlight it and move it to the front of the list.
+// @version      1.9
+// @description  Displays at least 10 of the shortest shortcuts for an anime after guessing phase, defined as the shortest substrings of length 10 or less for which the target anime (or any of its alt names) is a suggestion in the dropdown list (a 1 character penalty represented by "↓" is applied for every position below the top that the name associated with the shortcut appears). Adapted from https://github.com/tutti-amq/amq-scripts/blob/main/animeShortcuts.user.js All shortcuts (that aren't longer version of shorter shortcuts) with the smallest length are displayed. Click on a shortcut to highlight it and move it to the front of the list.
 // @author       Einlar, Tutti, kombofuud
 // @match        https://animemusicquiz.com/*
 // @match        https://*.animemusicquiz.com/*
@@ -15,6 +15,10 @@
 
 /**
  * CHANGELOG
+ *
+ * v1.9 (by kombofuud)
+ * - By default include shortcuts that contain only keyboard characters (ANSI 104 layout by default, configurable) unless KEYBOARD_LAYOUT_WHITELIST is set to null.
+ * - Add a few missing special characters to the DISALLOWED_SPECIAL_CHARACTERS list.
  *
  * v1.8 (by kombofuud)
  * - Cap the maximum range of shortcuts length to 3, configurable via the MAX_LENGTH_DIFFERENTIAL variable. For instance, for a show where the shortest shortcut has length 5, only shortcuts up to length 8 will be shown. This avoids showing shortcuts that are too long (and thus not interesting).
@@ -74,12 +78,23 @@ const TOP_SHORTCUTS_ONLY = false;
 const MAX_LENGTH_DIFFERENTIAL = 10;
 
 /**
-* Prevents any nonstandard keyboard characters from appearing
-*/
+ * Supported keyboard layouts, to be used when KEYBOARD_LAYOUT_WHITELIST is set.
+ * (I hope I got the character sets right for JIS and ISO, if I got any of the characters wrong (or the wrong version of a character), please let @kombofuud know in the scripts-for-games channel on the AMQ Discord server)
+ */
+const KEYBOARD_LAYOUTS = {
+  CUSTOM: "Add your custom layout here",
+  ANSI_104:
+    "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/? ",
+  ISO: "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`¬!\"£$%^&*()-_=+[{]};:'@#~\\|',<.>/? ",
+  JIS: "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`¥!\"#$%^&'()-_=+[{｢]}｣\\|;:『'…』,<.>/?・° ",
+};
 
-const WHITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST = true;
-const KEYBOARD_LAYOUT = "ANSI_104" // pick between "ANSI_104", "ISO", "JIS" or "CUSTOM"
-const CUSTOM_LAYOUT = "";
+/**
+ * If set to one of the supported keyboard layouts (e.g. "CUSTOM", "ANSI_104", "ISO", "JIS"), only characters present in that layout will be allowed in the shortcuts. Otherwise, the blacklist from DISALLOWED_SPECIAL_CHARACTERS will be used.
+ *
+ * @type {keyof typeof KEYBOARD_LAYOUTS | null}
+ */
+const KEYBOARD_LAYOUT_WHITELIST = "ANSI_104";
 
 /**
  * @see SEARCH_CHARACTER_REPLACEMENT_MAP from AMQ code
@@ -176,29 +191,16 @@ const ALLOWED_SPECIAL_CHARACTERS = [
  *
  * @type {string[]}
  */
-const DISALLOWED_SPECIAL_CHARACTERS = ["∞", "△", "↓","°","♡","∬"];
+const DISALLOWED_SPECIAL_CHARACTERS = ["∞", "△", "↓", "°", "♡", "∬"];
 
 /**
-* Determines a list of allowed characters when HITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST is true
-* I hope I got the character sets right for JIS and ISO, if I got any of the characters wrong (or the wrong version of a character), please let @kombofuud know in the scripts-for-games channel.
-*/
-const ANSI_104 = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`~!@#$%^&*()-_=+[{]}\\|;:'\",<.>/? ";
-const ISO = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`¬!\"£$%^&*()-_=+[{]};:'@#~\\|',<.>/? ";
-const JIS = "qwertyuiopasdfghjklzxcvbnmQWERTYUIOPASDFGHJKLZXCVBNM1234567890`¥!\"#$%^&'()-_=+[{｢]}｣\\|;:『'…』,<.>/?・° ";
-let FULL_CHARACTER_LIST;
-switch (KEYBOARD_LAYOUT){
-  case "ISO":
-    FULL_CHARACTER_LIST = ISO;
-    break;
-  case "JIS":
-    FULL_CHARACTER_LIST = ISO;
-    break;
-  case "CUSTOM":
-    FULL_CHARACTER_LIST = CUSTOM_LAYOUT;
-    break;
-  default:
-    FULL_CHARACTER_LIST = ANSI_104;
-}
+ * The active keyboard layout to be used when KEYBOARD_LAYOUT_WHITELIST. Null if the whitelist is not set. Defaults to ANSI_104 if the specified layout is not supported.
+ * @type {string | null}
+ */
+const ACTIVE_KEYBOARD_LAYOUT = KEYBOARD_LAYOUT_WHITELIST
+  ? KEYBOARD_LAYOUTS[KEYBOARD_LAYOUT_WHITELIST] || KEYBOARD_LAYOUTS["ANSI_104"]
+  : null;
+
 /**
  * Shortcuts to be shown
  *
@@ -272,11 +274,10 @@ const mapToAlternativeSubstrings = (substring) => {
 
   // Apply mandatory replacements
   let normalized = substring.replace(/./g, (char) => {
-    if (WHITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST) {
-        if (!FULL_CHARACTER_LIST.includes(char)) return "";
-    }
-    else{
-        if (DISALLOWED_SPECIAL_CHARACTERS.includes(char)) return "";
+    if (ACTIVE_KEYBOARD_LAYOUT) {
+      if (!ACTIVE_KEYBOARD_LAYOUT.includes(char)) return "";
+    } else {
+      if (DISALLOWED_SPECIAL_CHARACTERS.includes(char)) return "";
     }
     if (ALLOWED_SPECIAL_CHARACTERS.includes(/** @type {any} */ (char)))
       return char;
@@ -617,7 +618,7 @@ const setupMetadata = () => {
     version: "1.7",
     link: "https://github.com/Einlar/AMQScripts",
     description: `
-      <p>Displays 3 or more shortest dropdown shortcuts during the results phase.</p>
+      <p>Displays 10 or more shortest dropdown shortcuts during the results phase.</p>
       <p>The shortcuts displayed are the shortest substrings of length 10 or less for which the target anime (or any of its alt names) is the first suggestion in the dropdown list (or one of the top ones, in case it is not possible to do better).</p>
       <p>Shortcuts account for romaji/english names, and exploit the AMQ replacement rules for the dropdown (for instance, an optimal shortcut for "Kaguya-sama wa Kokurasetai?: Tensai-tachi no Renai Zunousen" is "? t", because a single space can be used to match any number of consecutive special characters).</p>
       <p>A few special characters are now allowed in the shortcuts (currently any of /*=+:;-?,.!@_#). Also all the characters that AMQ does not match with a space are allowed (e.g. "°", so you can use it as a shortcut for "Gintama°")</p>


### PR DESCRIPTION
My friends and I realized that many shows have some weird characters that aren't included in the blacklist, and which don't mesh well with the MAX_LENGTH_DIFFERENTIAL setting (normally, something 4 characters longer than another shortcut would always be harder to type, but not if the shorter shortcut is a weird extended ascii character. So rather than trying to blacklist those weird characters with the DISALLOWED_SPECIAL_CHARACTERS variable, we should just include a list of typable characters. I put in a few standard keyboard layouts (although I had a lot of trouble with figuring out which JIS characters to use and am still not completely confident I have the correct version of the character for some of the characters), and also added a custom one for people who have something beyond that. Additionally, the user can still turn this feature off with the WHITELIST_CHARACTERS_INSTEAD_OF_BLACKLIST variable.